### PR TITLE
Use variable for php7cc version

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.1-alpine
 
 MAINTAINER Yannick Pereira-Reis <yannick.pereira.reis@gmail.com>
 
+ENV PHP7CC_VERSION "1.2.1"
 ENV COMPOSER_HOME /composer
 ENV PATH "/composer/vendor/bin:$PATH"
 
@@ -11,7 +12,7 @@ RUN apk --no-cache add git curl \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && chmod +x /usr/local/bin/composer \
     && echo "date.timezone = Europe/Paris" >> /usr/local/etc/php/conf.d/symfony.ini \
-    && composer global require sstalle/php7cc \
+    && composer global require sstalle/php7cc $PHP7CC_VERSION \
     && rm /usr/local/bin/composer \
     && apk del git curl -r
 


### PR DESCRIPTION
Added variable to latest Dockerfile to avoid layer caching which would result in outdated library.

To test the (unexpected) old behaviour: 

run `docker run -it --rm -v $(pwd):/app ypereirareis/php7cc php7cc --version` - this will result in `PHP 7 Compatibility Checker 1.1.0` (latest version is [1.2.1](https://packagist.org/packages/sstalle/php7cc))